### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Unipile MCP Server
+[![smithery badge](https://smithery.ai/badge/mcp-unipile)](https://smithery.ai/server/mcp-unipile)
 
 MCP server for using Unipile to access messages across multiple messaging platforms.
 
@@ -58,6 +59,14 @@ You'll need a Unipile DSN and API key. You can obtain these from your Unipile da
 - `UNIPILE_API_KEY`: Your Unipile API key
 
 Note: Keep your API key secure and never commit it to version control.
+
+### Installing via Smithery
+
+To install mcp-unipile for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-unipile):
+
+```bash
+npx -y @smithery/cli install mcp-unipile --client claude
+```
 
 ### Docker Installation
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,22 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+build: {}
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - unipileDsn
+      - unipileApiKey
+    properties:
+      unipileDsn:
+        type: string
+        description: Your Unipile DSN, e.g., api8.unipile.com:13851
+      unipileApiKey:
+        type: string
+        description: Your Unipile API key
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'docker', args: ['run', '--rm', '-e', `UNIPILE_DSN=${config.unipileDsn}`, '-e', `UNIPILE_API_KEY=${config.unipileApiKey}`, 'buryhuang/mcp-unipile:latest']})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and what configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/mcp-unipile) and claiming it.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂